### PR TITLE
Bugfix: Setting user id on android is blocking main thread

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
@@ -53,6 +53,7 @@ public class FirebaseAnalytics extends Plugin {
 
       String userId = call.getString("userId");
       mFirebaseAnalytics.setUserId(userId);
+      call.success();
     } catch (Exception ex) {
       call.error(ex.getLocalizedMessage());
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "dist/",
     "ios/",
     "android/",
-    "CapacitorCommunityFirebaseAnalytics.podspec"
+    "CapacitorCommunityFirebaseAnalytics.podspec",
+    "tsconfig.json",
+    "src/"
   ],
   "keywords": [
     "capacitor",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "experimentalDecorators": true,
-    "lib": [
-      "dom",
-      "es2015"
-    ],
+    "lib": ["dom", "es2015"],
     "module": "es2015",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -16,7 +13,5 @@
     "sourceMap": true,
     "target": "es2015"
   },
-  "files": [
-    "src/index.ts"
-  ]
+  "files": ["src/index.ts", "src/definitions.ts", "src/web.ts"]
 }


### PR DESCRIPTION
When using `setUserId()` method with `await` in js code and deploying it on android, found that this method blocks execution of code. Found out that in native code, there is no `call.success()` or `call.resolve()` at the end of the method.
Tested after changes and everything is working ok now.