### PR TITLE
TypeScript error (TS2794) fix

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -283,7 +283,7 @@ export class FirebaseAnalyticsWeb extends WebPlugin
     const firebaseAppScript = this.scripts[0];
     const firebaseAnalyticsScript = this.scripts[1];
 
-    return new Promise(async (resolve, _reject) => {
+    return new Promise<void>(async (resolve, _reject) => {
       const scripts = this.scripts.map((script) => script.key);
       if (
         document.getElementById(scripts[0]) &&


### PR DESCRIPTION
After trying to update Angular from version 10 to version 11 and running `ng update` command, the migration could not be completed because there was some TypeScript error on installing packages, because TypeScript version was also changed from version 3.9.7 to 4.1.3 with which there are some new rules for handling promises:

<img width="1002" alt="Screenshot 2021-01-29 at 14 23 34" src="https://user-images.githubusercontent.com/45151703/106451880-7454a900-6487-11eb-8bcd-8d8577b8cd45.png">

<img width="1010" alt="Screenshot 2021-01-29 at 15 56 43" src="https://user-images.githubusercontent.com/45151703/106452886-c944ef00-6488-11eb-940c-f83cffb27aa6.png">
